### PR TITLE
Replace urls with empty string

### DIFF
--- a/lib/vienna.rb
+++ b/lib/vienna.rb
@@ -63,7 +63,7 @@ module Vienna
     def initialize(root = 'public')
       @app = Rack::Builder.new do
         use Rack::Static,
-          :urls => Dir.glob("#{root}/*").map { |fn| fn.gsub(/#{root}/, '')},
+          :urls => [""],
           :root => root,
           :index => 'index.html',
           :header_rules => [[:all, {'Cache-Control' => 'public, max-age=3600'}]]


### PR DESCRIPTION
Awesome, project!  I just found myself creating this exact same boilerplate for a quick prototype.

By using the empty string in the urls array, it will automatically match any file path, so we can avoid using Dir.glob.
