### PR TITLE
Bump dependencies versions.

### DIFF
--- a/vienna.gemspec
+++ b/vienna.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
   
-  spec.add_runtime_dependency 'rack', '~> 1.5'
+  spec.add_runtime_dependency 'rack', '~> 2.0'
   
   spec.add_development_dependency 'bundler', '~> 1.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'yard', '~> 0.8'
 end


### PR DESCRIPTION
To resolve #4.

`rake test` passes:
```
$ rake test
Run options: --seed 20364

# Running:

......

Finished in 0.013822s, 434.0906 runs/s, 795.8327 assertions/s.

6 runs, 11 assertions, 0 failures, 0 errors, 0 skips
```