### PR TITLE
Serve index file when path is '/'.

### DIFF
--- a/lib/vienna.rb
+++ b/lib/vienna.rb
@@ -38,7 +38,7 @@ module Vienna
     end
     
     def urls
-      Dir.glob("#{root}/*").map { |f| f.sub(root, '') }
+      Dir.glob("#{root}/*").map { |f| f.sub(root, '') }.prepend("/")
     end
     
     def root
@@ -54,7 +54,7 @@ module Vienna
     end
     
     def options
-      {urls: urls, root: root, index: index, header_rules: header_rules}
+      {urls: urls, root: root, index: index, header_rules: header_rules, cascade: true}
     end
     
     def call(env)


### PR DESCRIPTION
Currently, Vienna returns NotFound (404) when accessed with `/` path.
```
% rake test
Run options: --seed 27614

# Running:

..FF..

Finished in 0.036410s, 164.7899 runs/s, 302.1148 assertions/s.

  1) Failure:
Vienna::when requesting the root directory#test_0001_should serve the index path [spec.rb:21]:
--- expected
+++ actual
@@ -1 +1,2 @@
-"index"
+# encoding: ASCII-8BIT
+"404"


  2) Failure:
Vienna::when requesting the root directory#test_0002_should return a valid status code, that is 200: OK or 304: Not Modified [spec.rb:25]:
Expected [200, 304] to include 404.

6 runs, 11 assertions, 2 failures, 0 errors, 0 skips
```

Expected behaviour should be to return `index.html` instead of `404.html`.

My fix passes:

```
% rake test
Run options: --seed 32465

# Running:

......

Finished in 0.020588s, 291.4319 runs/s, 534.2918 assertions/s.

6 runs, 11 assertions, 0 failures, 0 errors, 0 skips
```